### PR TITLE
allow a configurable collection instead of all HTML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,22 @@ sitemap: true || false # defaults to true, if false no entry for this document w
 For the whole site you can set defaults using the plugin configuration in your docpad.cson or docpad.coffee file.
 
 ``` coffee
-	plugins:
-		sitemap:
-			cachetime: 600000
-			changefreq: 'weekly'
-			priority: 0.5
+  plugins:
+    sitemap:
+      cachetime: 600000
+      changefreq: 'weekly'
+      priority: 0.5
 ```
 
 Site URL is read from the `templateData.site.url` property also in that same config file, but will fallback to the `hostname` property in the plugin config if not found.
 
+By default all HTML files on your site will be considered for inclusion. To specify a different collection, add to your Docpad configuration file:
+
+``` coffee
+  plugins:
+    sitemap:
+      collection: 'myCollection'
+```
 
 ## License
 Licensed under the incredibly [permissive](http://en.wikipedia.org/wiki/Permissive_free_software_licence) [MIT License](http://creativecommons.org/licenses/MIT/)

--- a/src/sitemap.plugin.coffee
+++ b/src/sitemap.plugin.coffee
@@ -49,9 +49,11 @@ module.exports = (BasePlugin) ->
 			sitemapPath = docpad.getConfig().outPath+'/sitemap.xml'
 
 			docpad.log('debug', 'Creating sitemap in ' + sitemapPath)
-
-			# loop over just the html files in the resulting collection
-			docpad.getCollection('html').sortCollection(date:9).forEach (document) ->
+			
+			# allow a configured collection or just use all html files
+			collection = config.collection ? 'html'
+			# loop over just the files in the resulting collection
+			docpad.getCollection(collection).sortCollection(date:9).forEach (document) ->
 				if (document.get('sitemap') is null or document.get('sitemap') isnt false) and (document.get('write') is null or document.get('write') isnt false) and document.get('ignored') isnt true
 					# create document's sitemap data
 					data =


### PR DESCRIPTION
In my case the default behavior of including all HTML files was not feasible, since I had some libraries in my /src/files directory that included HTML files (docs and such). This change allows a configurable collection to be used instead.
